### PR TITLE
Address range support for 24 and 32 bit FRAM SPI chips.

### DIFF
--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -161,6 +161,7 @@ void Adafruit_FRAM_SPI::writeEnable (bool enable)
 void Adafruit_FRAM_SPI::write8 (uint32_t addr, uint8_t value)
 {
   digitalWrite(_cs, LOW);
+  SPItransfer(OPCODE_WRITE);
   writeAddress(addr);
   SPItransfer(value);
   /* CS on the rising edge commits the WRITE */

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -72,10 +72,9 @@ boolean Adafruit_FRAM_SPI::begin(int8_t cs, uint8_t nAddressSizeBytes)
 {
   if (cs == -1)
   {
-    Serial.print("No cs pin specified");
+    //Serial.print("No cs pin specified");
     return false;
   }
-  Serial.print("CS is "); Serial.println(cs);
 
   _cs = cs;
   setAddressSize(nAddressSizeBytes);
@@ -107,12 +106,12 @@ boolean Adafruit_FRAM_SPI::begin(int8_t cs, uint8_t nAddressSizeBytes)
 
   if (manufID != 0x04 && manufID != 0x7f)
   {
-    Serial.print("Unexpected Manufacturer ID: 0x"); Serial.println(manufID, HEX);
+    //Serial.print("Unexpected Manufacturer ID: 0x"); Serial.println(manufID, HEX);
     return false;
   }
   if (prodID != 0x0302 && prodID != 0x7f7f)
   {
-    Serial.print("Unexpected Product ID: 0x"); Serial.println(prodID, HEX);
+    //Serial.print("Unexpected Product ID: 0x"); Serial.println(prodID, HEX);
     return false;
   }
 

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -72,7 +72,7 @@ boolean Adafruit_FRAM_SPI::begin(int8_t cs, uint8_t nAddressSizeBytes)
 {
   if (cs == -1)
   {
-    //Serial.print("No cs pin specified");
+    Serial.println("No cs pin specified!");
     return false;
   }
 
@@ -88,8 +88,10 @@ boolean Adafruit_FRAM_SPI::begin(int8_t cs, uint8_t nAddressSizeBytes)
 
 #ifdef __SAM3X8E__
     SPI.setClockDivider (9); // 9.3 MHz
+#elif defined(STM32F2XX)
+	SPI.setClockDivider (SPI_CLOCK_DIV2); // Particle Photon top speed 36MHz
 #else
-    SPI.setClockDivider (SPI_CLOCK_DIV2); // 8 MHz
+	SPI.setClockDivider (SPI_CLOCK_DIV2); // 8 MHz
 #endif
 
     SPI.setDataMode(SPI_MODE0);
@@ -106,12 +108,12 @@ boolean Adafruit_FRAM_SPI::begin(int8_t cs, uint8_t nAddressSizeBytes)
 
   if (manufID != 0x04 && manufID != 0x7f)
   {
-    //Serial.print("Unexpected Manufacturer ID: 0x"); Serial.println(manufID, HEX);
+    Serial.print("Unexpected Manufacturer ID: 0x"); Serial.println(manufID, HEX);
     return false;
   }
   if (prodID != 0x0302 && prodID != 0x7f7f)
   {
-    //Serial.print("Unexpected Product ID: 0x"); Serial.println(prodID, HEX);
+    Serial.print("Unexpected Product ID: 0x"); Serial.println(prodID, HEX);
     return false;
   }
 

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -89,7 +89,10 @@ boolean Adafruit_FRAM_SPI::begin(int8_t cs, uint8_t nAddressSizeBytes)
 #ifdef __SAM3X8E__
     SPI.setClockDivider (9); // 9.3 MHz
 #elif defined(STM32F2XX)
-	SPI.setClockDivider (SPI_CLOCK_DIV2); // Particle Photon top speed 36MHz
+	// Is seems the photon SPI0 clock runs at 60MHz, but SPI1 runs at
+	// 30MHz, so the DIV will need to change if this is ever extended
+	// to cover SPI1
+	SPI.setClockDivider (SPI_CLOCK_DIV4); // Particle Photon SPI @ 15MHz
 #else
 	SPI.setClockDivider (SPI_CLOCK_DIV2); // 8 MHz
 #endif

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -72,7 +72,7 @@ boolean Adafruit_FRAM_SPI::begin(int8_t cs, uint8_t nAddressSizeBytes)
 {
   if (cs == -1)
   {
-    Serial.println("No cs pin specified!");
+    //Serial.println("No cs pin specified!");
     return false;
   }
 
@@ -108,12 +108,12 @@ boolean Adafruit_FRAM_SPI::begin(int8_t cs, uint8_t nAddressSizeBytes)
 
   if (manufID != 0x04 && manufID != 0x7f)
   {
-    Serial.print("Unexpected Manufacturer ID: 0x"); Serial.println(manufID, HEX);
+    //Serial.print("Unexpected Manufacturer ID: 0x"); Serial.println(manufID, HEX);
     return false;
   }
   if (prodID != 0x0302 && prodID != 0x7f7f)
   {
-    Serial.print("Unexpected Product ID: 0x"); Serial.println(prodID, HEX);
+    //Serial.print("Unexpected Product ID: 0x"); Serial.println(prodID, HEX);
     return false;
   }
 

--- a/Adafruit_FRAM_SPI.h
+++ b/Adafruit_FRAM_SPI.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     Adafruit_FRAM_SPI.h
     @author   KTOWN (Adafruit Industries)
 
@@ -57,23 +57,29 @@ typedef enum opcodes_e
 
 class Adafruit_FRAM_SPI {
  public:
+  Adafruit_FRAM_SPI();
   Adafruit_FRAM_SPI(int8_t cs);
   Adafruit_FRAM_SPI(int8_t clk, int8_t miso, int8_t mosi, int8_t cs);
 
-  boolean  begin  (void);
+  boolean  begin  ();
+  boolean  begin  (uint8_t nAddressSizeBytes);
+  boolean  begin  (int8_t cs, uint8_t nAddressSizeBytes);
   void     writeEnable (bool enable);
-  void     write8 (uint16_t addr, uint8_t value);
-  void     write (uint16_t addr, const uint8_t *values, size_t count);
-  uint8_t  read8  (uint16_t addr);
-  void     read (uint16_t addr, uint8_t *values, size_t count);
+  void     write8 (uint32_t addr, uint8_t value);
+  void     write (uint32_t addr, const uint8_t *values, size_t count);
+  uint8_t  read8  (uint32_t addr);
+  void     read (uint32_t addr, uint8_t *values, size_t count);
   void     getDeviceID(uint8_t *manufacturerID, uint16_t *productID);
   uint8_t  getStatusRegister(void);
   void     setStatusRegister(uint8_t value);
+  void     setAddressSize(uint8_t nAddressSize);
 
  private:
   uint8_t  SPItransfer(uint8_t x);
+  void     writeAddress(uint32_t addr);
 
   boolean _framInitialised;
+  uint8_t  _nAddressSizeBytes;
   int8_t _cs, _clk, _mosi, _miso;
 };
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ATSAM21D           |      X       |             |            |
 ATtiny85 @ 16MHz   |             |             |     X       | 
 ATtiny85 @ 8MHz    |             |             |     X       | 
 Intel Curie @ 32MHz |             |             |     X       | 
-STM32F2            |             |             |     X       | 
+STM32F2            |      X      |             |             |STM32F205RGY6 
 
   * ATmega328 @ 16MHz : Arduino UNO, Adafruit Pro Trinket 5V, Adafruit Metro 328, Adafruit Metro Mini
   * ATmega328 @ 12MHz : Adafruit Pro Trinket 3V
@@ -48,5 +48,6 @@ STM32F2            |             |             |     X       |
   * ATSAM21D : Arduino Zero, M0 Pro
   * ATtiny85 @ 16MHz : Adafruit Trinket 5V
   * ATtiny85 @ 8MHz : Adafruit Gemma, Arduino Gemma, Adafruit Trinket 3V
+  * STM32F2 @ 120MHz : Particle Photon
 
 <!-- END COMPATIBILITY TABLE -->

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ATSAM21D           |      X       |             |            |
 ATtiny85 @ 16MHz   |             |             |     X       | 
 ATtiny85 @ 8MHz    |             |             |     X       | 
 Intel Curie @ 32MHz |             |             |     X       | 
-STM32F2            |      X      |             |             |STM32F205RGY6 
+STM32F2            |      X      |             |             | 
 
   * ATmega328 @ 16MHz : Arduino UNO, Adafruit Pro Trinket 5V, Adafruit Metro 328, Adafruit Metro Mini
   * ATmega328 @ 12MHz : Adafruit Pro Trinket 3V
@@ -48,6 +48,6 @@ STM32F2            |      X      |             |             |STM32F205RGY6
   * ATSAM21D : Arduino Zero, M0 Pro
   * ATtiny85 @ 16MHz : Adafruit Trinket 5V
   * ATtiny85 @ 8MHz : Adafruit Gemma, Arduino Gemma, Adafruit Trinket 3V
-  * STM32F2 @ 120MHz : Particle Photon
+  * STM32F2 @ 120MHz : Adafruit WICED Feather, Particle Photon
 
 <!-- END COMPATIBILITY TABLE -->

--- a/examples/FRAMInfo/FRAMInfo.ino
+++ b/examples/FRAMInfo/FRAMInfo.ino
@@ -1,0 +1,89 @@
+#include <SPI.h>
+#include "Adafruit_FRAM_SPI.h"
+
+/* Example code to interrogate Adafruit SPI FRAM breakout for address size and storage capacity */
+
+/* WARNING: Running this sketch will overwrite all existing data on the FRAM breakout */
+
+
+uint8_t FRAM_CS = 10;
+Adafruit_FRAM_SPI fram = Adafruit_FRAM_SPI(FRAM_CS);  // use hardware SPI
+
+uint8_t FRAM_SCK = 13;
+uint8_t FRAM_MISO = 12;
+uint8_t FRAM_MOSI = 11;
+//Or use software SPI, any pins!
+//Adafruit_FRAM_SPI fram = Adafruit_FRAM_SPI(FRAM_SCK, FRAM_MISO, FRAM_MOSI, FRAM_CS);
+
+uint8_t           addrSizeInBytes = 2; //Default to address size of two bytes
+uint32_t          memSize;
+
+#if defined(ARDUINO_ARCH_SAMD)
+// for Zero, output on USB Serial console, remove line below if using programming port to program the Zero!
+   #define Serial SerialUSB
+#endif
+
+
+int32_t testReadBack(uint32_t addr, int32_t data) {
+  int32_t check = !data;
+  fram.writeEnable(true);
+  fram.write(addr, (uint8_t*)&data, sizeof(data));
+  fram.writeEnable(false);
+  fram.read(addr, (uint8_t*)&check, sizeof(check));
+  return check;
+}
+
+bool testAddrSize(uint8_t addrSize) {
+  fram.setAddressSize(addrSize);
+  if (testReadBack(0, 0xbeefbead) == 0xbeefbead)
+    return true;
+  return false;
+}
+
+
+void setup(void) {
+  #ifndef ESP8266
+    while (!Serial);     // will pause Zero, Leonardo, etc until serial console opens
+  #endif
+
+  Serial.begin(9600);
+  
+  if (fram.begin(addrSizeInBytes)) {
+    Serial.println("Found SPI FRAM");
+  } else {
+    Serial.println("No SPI FRAM found ... check your connections\r\n");
+    while (1);
+  }
+  
+  if (testAddrSize(2))
+    addrSizeInBytes = 2;
+  else if (testAddrSize(3))
+    addrSizeInBytes = 3;
+  else if (testAddrSize(4))
+    addrSizeInBytes = 4;
+  else {
+    Serial.println("SPI FRAM can not be read/written with any address size\r\n");
+    while (1);
+  }
+
+  Serial.println("SPI FRAM address size is ");
+  Serial.println(addrSizeInBytes);
+  Serial.println(" bytes.");
+  
+  memSize = 0;
+  while (testReadBack(memSize, memSize) == memSize) {
+    memSize += 4;
+  }
+  
+  Serial.println("SPI FRAM capacity appears to be..");
+  Serial.print(memSize); Serial.println(" bytes");
+  Serial.print(memSize/0x1000); Serial.println(" KBytes");
+  Serial.print((memSize*8)/0x1000); Serial.println(" KBits");
+  if (memSize >= 0x100000) {
+    Serial.print((memSize*8)/0x100000); Serial.println(" MBits");
+  }
+}
+
+void loop(void) {
+
+}

--- a/examples/FRAMInfo/FRAMInfo.ino
+++ b/examples/FRAMInfo/FRAMInfo.ino
@@ -3,10 +3,10 @@
 
 /* Example code to interrogate Adafruit SPI FRAM breakout for address size and storage capacity */
 
-/* NOTE: This sketch is designed to preserve existing data on the FRAM breakout */
+/* NOTE: This sketch will overwrite data already on the FRAM breakout */
 
 uint8_t FRAM_CS = 10;
-Adafruit_FRAM_SPI fram = Adafruit_FRAM_SPI(FRAM_CS);  // use hardware SPI
+Adafruit_FRAM_SPI fram = Adafruit_FRAM_SPI();  // use hardware SPI
 
 uint8_t FRAM_SCK = 13;
 uint8_t FRAM_MISO = 12;
@@ -56,7 +56,7 @@ void setup(void) {
 
   Serial.begin(9600);
   
-  if (fram.begin(addrSizeInBytes)) {
+  if (fram.begin(FRAM_CS, addrSizeInBytes)) {
     Serial.println("Found SPI FRAM");
   } else {
     Serial.println("No SPI FRAM found ... check your connections\r\n");


### PR DESCRIPTION
1. Added support for 3 and 4 byte addresses.

2. Allow default manufacturer and product IDs. (0x7f, 0x7f7f)

3. Added constructor that requires no parameters.

4. Added begin(.) method that takes an address byte size parameter, if > 2

5. Added begin(..) method that takes address byte size and CS pin parameter, for when the new zero parameter constructor is used.

6. Added Particle Photon as a tested and working device.

7. Added a new example sketch (FRAMInfo) that interrogates then displays the FRAM address size and capacity.

All existing sketches using this API should still work unmodified, the only relevant API change for them will be that the unsigned 16bit address parameter passed to reads and writes will now be promoted to an unsigned 32bit, this should not produce compiler warnings. 
