### PR TITLE
Use SPI transactions for better compatibility

### DIFF
--- a/Adafruit_FRAM_SPI.h
+++ b/Adafruit_FRAM_SPI.h
@@ -81,6 +81,10 @@ class Adafruit_FRAM_SPI {
   boolean _framInitialised;
   uint8_t  _nAddressSizeBytes;
   int8_t _cs, _clk, _mosi, _miso;
+
+  #if defined(SPI_HAS_TRANSACTION)
+  SPISettings spiSettings;
+  #endif
 };
 
 #endif


### PR DESCRIPTION
SPI transfers now use SPI.beginTransaction() to set the parameters, for better compatibility with other devices using other parameters.
When an old version of the SPI library is used, the individual functions to set SPI parameters are used.

Changes:
- Call SPI.beginTransaction() before selecting the device
- Call SPI.endTransaction() after deselecting the device