### PR TITLE
centralize supported devices as look up table

### DIFF
--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -34,8 +34,8 @@
 
 /// Supported flash devices
 const struct {
-  uint8_t manufID; //< Manufacture ID
-  uint16_t prodID; //< Product ID
+  uint8_t manufID; ///< Manufacture ID
+  uint16_t prodID; ///< Product ID
 } _supported_devices[] = {
     // Sorted in numerical order
     // Fujitsu

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -33,8 +33,8 @@
 #include "Adafruit_FRAM_SPI.h"
 
 const struct {
-  uint8_t manufID;
-  uint16_t prodID;
+  uint8_t manufID; // Manufacture ID
+  uint16_t prodID; // Product ID
 } _supported_devices[] = {
     // Sorted in numerical order
     // Fujitsu
@@ -51,6 +51,14 @@ const struct {
     {0xAE, 0x8305} // MR45V064B
 };
 
+/*!
+ *  @brief  Check if the flash device is supported
+ *  @param  manufID
+ *          ManufactureID to be checked
+ *  @param  prodID
+ *          ProductID to be checked
+ *  @return true if supported
+ */
 static bool check_supported_device(uint8_t manufID, uint16_t prodID) {
   for (uint8_t i = 0;
        i < sizeof(_supported_devices) / sizeof(_supported_devices[0]); i++) {
@@ -111,7 +119,7 @@ Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t clk, int8_t miso, int8_t mosi,
  *          doing anything else)
  *  @param  nAddressSizeBytes
  *          sddress size in bytes (default 2)
- *  @return true if succesful
+ *  @return true if successful
  */
 bool Adafruit_FRAM_SPI::begin(uint8_t nAddressSizeBytes) {
   setAddressSize(nAddressSizeBytes);

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -32,9 +32,10 @@
 
 #include "Adafruit_FRAM_SPI.h"
 
+/// Supported flash devices
 const struct {
-  uint8_t manufID; // Manufacture ID
-  uint16_t prodID; // Product ID
+  uint8_t manufID; //< Manufacture ID
+  uint16_t prodID; //< Product ID
 } _supported_devices[] = {
     // Sorted in numerical order
     // Fujitsu
@@ -45,7 +46,7 @@ const struct {
     {0x04, 0x4903}, // MB85RS4MT
 
     // Cypress
-    {0x7F, 0x7F7f}, // FM25V02
+    {0x7F, 0x7F7f}, // FM25V02 (manu = 7F7F7F7F7F7FC2, device = 0x2200)
 
     // Lapis
     {0xAE, 0x8305} // MR45V064B


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

Centralize the supported device as lookup table, make it easier to add new devices. Also this reduce the chance of manufacture & product ID that pass the check but not actually FRAM e.g Manu = 0x04, Proudct = 0x8305
