### PR TITLE
auto-detect address size based on jedec id

### DIFF
--- a/Adafruit_FRAM_SPI.h
+++ b/Adafruit_FRAM_SPI.h
@@ -58,8 +58,6 @@ public:
 
 private:
   Adafruit_SPIDevice *spi_dev = NULL;
-
-  boolean _framInitialised;
   uint8_t _nAddressSizeBytes;
 };
 


### PR DESCRIPTION
auto-detect address size based on jedec id instead of having user to explicitly passed it in begin(). Can still be overwritten afterwards by `setAddressSize()` (though I don't think people will need to do that at all). solved issue in https://forums.adafruit.com/viewtopic.php?f=31&t=176578
