### PR TITLE
add new constructor with SPI clock freq as parameter

### DIFF
--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -99,18 +99,19 @@ Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t cs, SPIClass *theSPI) {
  *  @brief  Instantiates a new SPI FRAM class using hardware SPI
  *  @param  cs
  *          Required chip select pin number
- *  @param  freq 
+ *  @param  freq
  *          The SPI clock frequency to use, defaults to 1MHz
  *  @param  *theSPI
  *          SPI interface object, defaults to &SPI
  */
-Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t cs,  uint32_t freq, SPIClass *theSPI) {
+Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t cs, uint32_t        freq,
+                                     SPIClass *theSPI) {
   if (spi_dev) {
     delete spi_dev;
   }
 
-  spi_dev = new Adafruit_SPIDevice(cs, freq, SPI_BITORDER_MSBFIRST,
-                                   SPI_MODE0, theSPI);
+  spi_dev = new Adafruit_SPIDevice(cs, freq, SPI_BITORDER_MSBFIRST, SPI_MODE0,
+                                   theSPI);
 }
 
 /*!

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -96,6 +96,24 @@ Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t cs, SPIClass *theSPI) {
 }
 
 /*!
+ *  @brief  Instantiates a new SPI FRAM class using hardware SPI
+ *  @param  cs
+ *          Required chip select pin number
+ *  @param  freq 
+ *          The SPI clock frequency to use, defaults to 1MHz
+ *  @param  *theSPI
+ *          SPI interface object, defaults to &SPI
+ */
+Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t cs,  uint32_t freq, SPIClass *theSPI) {
+  if (spi_dev) {
+    delete spi_dev;
+  }
+
+  spi_dev = new Adafruit_SPIDevice(cs, freq, SPI_BITORDER_MSBFIRST,
+                                   SPI_MODE0, theSPI);
+}
+
+/*!
  *  @brief  Instantiates a new SPI FRAM class using bitbang SPI
  *  @param  clk
  *          CLK pin

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -104,7 +104,7 @@ Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t cs, SPIClass *theSPI) {
  *  @param  *theSPI
  *          SPI interface object, defaults to &SPI
  */
-Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t cs, uint32_t        freq,
+Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t cs, uint32_t freq,
                                      SPIClass *theSPI) {
   if (spi_dev) {
     delete spi_dev;

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -85,27 +85,11 @@ static uint32_t check_supported_device(uint8_t manufID, uint16_t prodID) {
  *          Required chip select pin number
  *  @param  *theSPI
  *          SPI interface object, defaults to &SPI
- */
-Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t cs, SPIClass *theSPI) {
-  if (spi_dev) {
-    delete spi_dev;
-  }
-
-  spi_dev = new Adafruit_SPIDevice(cs, 1000000, SPI_BITORDER_MSBFIRST,
-                                   SPI_MODE0, theSPI);
-}
-
-/*!
- *  @brief  Instantiates a new SPI FRAM class using hardware SPI
- *  @param  cs
- *          Required chip select pin number
  *  @param  freq
  *          The SPI clock frequency to use, defaults to 1MHz
- *  @param  *theSPI
- *          SPI interface object, defaults to &SPI
  */
-Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t cs, uint32_t freq,
-                                     SPIClass *theSPI) {
+Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t cs, SPIClass *theSPI,
+                                     uint32_t freq) {
   if (spi_dev) {
     delete spi_dev;
   }

--- a/Adafruit_FRAM_SPI.h
+++ b/Adafruit_FRAM_SPI.h
@@ -42,9 +42,9 @@ typedef enum opcodes_e {
  */
 class Adafruit_FRAM_SPI {
 public:
-  Adafruit_FRAM_SPI(int8_t cs, SPIClass *theSPI = &SPI);
+  Adafruit_FRAM_SPI(int8_t cs, SPIClass *theSPI = &SPI,
+                    uint32_t freq = 1000000);
   Adafruit_FRAM_SPI(int8_t clk, int8_t miso, int8_t mosi, int8_t cs);
-  Adafruit_FRAM_SPI(int8_t cs, uint32_t freq, SPIClass *theSPI = &SPI);
 
   bool begin(uint8_t nAddressSizeBytes = 2);
   void writeEnable(bool enable);

--- a/Adafruit_FRAM_SPI.h
+++ b/Adafruit_FRAM_SPI.h
@@ -44,7 +44,7 @@ class Adafruit_FRAM_SPI {
 public:
   Adafruit_FRAM_SPI(int8_t cs, SPIClass *theSPI = &SPI);
   Adafruit_FRAM_SPI(int8_t clk, int8_t miso, int8_t mosi, int8_t cs);
-  Adafruit_FRAM_SPI(int8_t cs,  uint32_t freq, SPIClass *theSPI = &SPI);
+  Adafruit_FRAM_SPI(int8_t cs, uint32_t freq, SPIClass *theSPI = &SPI);
 
   bool begin(uint8_t nAddressSizeBytes = 2);
   void writeEnable(bool enable);

--- a/Adafruit_FRAM_SPI.h
+++ b/Adafruit_FRAM_SPI.h
@@ -44,7 +44,7 @@ class Adafruit_FRAM_SPI {
 public:
   Adafruit_FRAM_SPI(int8_t cs, SPIClass *theSPI = &SPI);
   Adafruit_FRAM_SPI(int8_t clk, int8_t miso, int8_t mosi, int8_t cs);
-  Adafruit_FRAM_SPI(int8_t cs,  uint32_t freq = 1000000, SPIClass *theSPI = &SPI);
+  Adafruit_FRAM_SPI(int8_t cs,  uint32_t freq, SPIClass *theSPI = &SPI);
 
   bool begin(uint8_t nAddressSizeBytes = 2);
   void writeEnable(bool enable);

--- a/Adafruit_FRAM_SPI.h
+++ b/Adafruit_FRAM_SPI.h
@@ -44,6 +44,7 @@ class Adafruit_FRAM_SPI {
 public:
   Adafruit_FRAM_SPI(int8_t cs, SPIClass *theSPI = &SPI);
   Adafruit_FRAM_SPI(int8_t clk, int8_t miso, int8_t mosi, int8_t cs);
+  Adafruit_FRAM_SPI(int8_t cs,  uint32_t freq = 1000000, SPIClass *theSPI = &SPI);
 
   bool begin(uint8_t nAddressSizeBytes = 2);
   void writeEnable(bool enable);


### PR DESCRIPTION
Using the existing constructors it's not possible to set the SPI clock frequency. The frequency is fixed to 1MHz. 
It should be possible to set the clock frequency for hardware SPI. 

This pull request ...
- Adds a new constructor, which allows setting the SPI clock frequency (default is still 1MHz).

Thanks a lot!