### PR TITLE
write method param const-ness

### DIFF
--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -204,7 +204,8 @@ void Adafruit_FRAM_SPI::write8(uint32_t addr, uint8_t value) {
  *   @param count
  *           The number of bytes to write
  */
-void Adafruit_FRAM_SPI::write(uint32_t addr, const uint8_t *values, size_t count) {
+void Adafruit_FRAM_SPI::write(uint32_t addr, const uint8_t *values,
+                              size_t count) {
   uint8_t prebuf[10];
   uint8_t i = 0;
 

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -204,7 +204,7 @@ void Adafruit_FRAM_SPI::write8(uint32_t addr, uint8_t value) {
  *   @param count
  *           The number of bytes to write
  */
-void Adafruit_FRAM_SPI::write(uint32_t addr, uint8_t *values, size_t count) {
+void Adafruit_FRAM_SPI::write(uint32_t addr, const uint8_t *values, size_t count) {
   uint8_t prebuf[10];
   uint8_t i = 0;
 

--- a/Adafruit_FRAM_SPI.h
+++ b/Adafruit_FRAM_SPI.h
@@ -49,7 +49,7 @@ public:
   bool begin(uint8_t nAddressSizeBytes = 2);
   void writeEnable(bool enable);
   void write8(uint32_t addr, uint8_t value);
-  void write(uint32_t addr, uint8_t *values, size_t count);
+  void write(uint32_t addr, const uint8_t *values, size_t count);
   uint8_t read8(uint32_t addr);
   void read(uint32_t addr, uint8_t *values, size_t count);
   void getDeviceID(uint8_t *manufacturerID, uint16_t *productID);


### PR DESCRIPTION
fix https://github.com/adafruit/Adafruit_FRAM_SPI/issues/25

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

Scope: added `const` keyword to `void Adafruit_FRAM_SPI::write(uint32_t addr, const uint8_t *values, size_t count)`

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

This change is dependent on the [pull request](https://github.com/adafruit/Adafruit_BusIO/pull/84) on the underlying lib Adafruit_BusIO. Tested with ESP32 DevKitC (espressif) and the Adafruit SPI Non-Volatile FRAM Breakout - 64Kbit / 8KByte (MB85RS64V).

Thank you!