### PR TITLE
Added bool return types to the SPI functions that doesn't return anything

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Doxyfile*
 doxygen_sqlite3.db
 html
 *.tmp
+.vscode/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "*.tcc": "cpp"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.tcc": "cpp"
+    }
+}

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -282,7 +282,7 @@ bool Adafruit_FRAM_SPI::getDeviceID(uint8_t *manufacturerID,
   uint8_t cmd = OPCODE_RDID;
   uint8_t a[4] = {0, 0, 0, 0};
 
-  if(!spi_dev->write_then_read(&cmd, 1, a, 4)) {
+  if (!spi_dev->write_then_read(&cmd, 1, a, 4)) {
     return false;
   }
 

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -282,7 +282,7 @@ bool Adafruit_FRAM_SPI::getDeviceID(uint8_t *manufacturerID,
   uint8_t cmd = OPCODE_RDID;
   uint8_t a[4] = {0, 0, 0, 0};
 
-  if( !spi_dev->write_then_read(&cmd, 1, a, 4) ) {
+  if(!spi_dev->write_then_read(&cmd, 1, a, 4)) {
     return false;
   }
 

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -158,10 +158,11 @@ bool Adafruit_FRAM_SPI::begin(uint8_t nAddressSizeBytes) {
 }
 
 /*!
-    @brief  Enables or disables writing to the SPI flash
-    @param enable
-            True enables writes, false disables writes
-*/
+ *  @brief  Enables or disables writing to the SPI flash
+ *  @param enable
+ *          True enables writes, false disables writes
+ *  @return true if successful
+ */
 bool Adafruit_FRAM_SPI::writeEnable(bool enable) {
   uint8_t cmd;
 
@@ -179,6 +180,7 @@ bool Adafruit_FRAM_SPI::writeEnable(bool enable) {
  *         The 32-bit address to write to in FRAM memory
  *  @param value
  *         The 8-bit value to write at framAddr
+ *  @return true if successful
  */
 bool Adafruit_FRAM_SPI::write8(uint32_t addr, uint8_t value) {
   uint8_t buffer[10];
@@ -204,6 +206,7 @@ bool Adafruit_FRAM_SPI::write8(uint32_t addr, uint8_t value) {
  *           The pointer to an array of 8-bit values to write starting at addr
  *   @param count
  *           The number of bytes to write
+ *   @return true if successful
  */
 bool Adafruit_FRAM_SPI::write(uint32_t addr, const uint8_t *values,
                               size_t count) {
@@ -252,6 +255,7 @@ uint8_t Adafruit_FRAM_SPI::read8(uint32_t addr) {
  *           The pointer to an array of 8-bit values to read starting at addr
  *   @param  count
  *           The number of bytes to read
+ *   @return true if successful
  */
 bool Adafruit_FRAM_SPI::read(uint32_t addr, uint8_t *values, size_t count) {
   uint8_t buffer[10];
@@ -276,6 +280,7 @@ bool Adafruit_FRAM_SPI::read(uint32_t addr, uint8_t *values, size_t count) {
  *          The memory density (bytes 15..8) and proprietary
  *          Product ID fields (bytes 7..0). Should be 0x0302 for
  *          the MB85RS64VPNF-G-JNERE1.
+ *   @return true if successful
  */
 bool Adafruit_FRAM_SPI::getDeviceID(uint8_t *manufacturerID,
                                     uint16_t *productID) {
@@ -319,6 +324,7 @@ uint8_t Adafruit_FRAM_SPI::getStatusRegister() {
  *   @brief  Sets the status register
  *   @param  value
  *           value that will be set
+ *   @return true if successful
  */
 bool Adafruit_FRAM_SPI::setStatusRegister(uint8_t value) {
   uint8_t cmd[2];

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -162,7 +162,7 @@ bool Adafruit_FRAM_SPI::begin(uint8_t nAddressSizeBytes) {
     @param enable
             True enables writes, false disables writes
 */
-void Adafruit_FRAM_SPI::writeEnable(bool enable) {
+bool Adafruit_FRAM_SPI::writeEnable(bool enable) {
   uint8_t cmd;
 
   if (enable) {
@@ -170,7 +170,7 @@ void Adafruit_FRAM_SPI::writeEnable(bool enable) {
   } else {
     cmd = OPCODE_WRDI;
   }
-  spi_dev->write(&cmd, 1);
+  return spi_dev->write(&cmd, 1);
 }
 
 /*!
@@ -180,7 +180,7 @@ void Adafruit_FRAM_SPI::writeEnable(bool enable) {
  *  @param value
  *         The 8-bit value to write at framAddr
  */
-void Adafruit_FRAM_SPI::write8(uint32_t addr, uint8_t value) {
+bool Adafruit_FRAM_SPI::write8(uint32_t addr, uint8_t value) {
   uint8_t buffer[10];
   uint8_t i = 0;
 
@@ -193,7 +193,7 @@ void Adafruit_FRAM_SPI::write8(uint32_t addr, uint8_t value) {
   buffer[i++] = (uint8_t)(addr & 0xFF);
   buffer[i++] = value;
 
-  spi_dev->write(buffer, i);
+  return spi_dev->write(buffer, i);
 }
 
 /*!
@@ -205,7 +205,7 @@ void Adafruit_FRAM_SPI::write8(uint32_t addr, uint8_t value) {
  *   @param count
  *           The number of bytes to write
  */
-void Adafruit_FRAM_SPI::write(uint32_t addr, const uint8_t *values,
+bool Adafruit_FRAM_SPI::write(uint32_t addr, const uint8_t *values,
                               size_t count) {
   uint8_t prebuf[10];
   uint8_t i = 0;
@@ -218,7 +218,7 @@ void Adafruit_FRAM_SPI::write(uint32_t addr, const uint8_t *values,
   prebuf[i++] = (uint8_t)(addr >> 8);
   prebuf[i++] = (uint8_t)(addr & 0xFF);
 
-  spi_dev->write(values, count, prebuf, i);
+  return spi_dev->write(values, count, prebuf, i);
 }
 
 /*!
@@ -253,7 +253,7 @@ uint8_t Adafruit_FRAM_SPI::read8(uint32_t addr) {
  *   @param  count
  *           The number of bytes to read
  */
-void Adafruit_FRAM_SPI::read(uint32_t addr, uint8_t *values, size_t count) {
+bool Adafruit_FRAM_SPI::read(uint32_t addr, uint8_t *values, size_t count) {
   uint8_t buffer[10];
   uint8_t i = 0;
 
@@ -265,7 +265,7 @@ void Adafruit_FRAM_SPI::read(uint32_t addr, uint8_t *values, size_t count) {
   buffer[i++] = (uint8_t)(addr >> 8);
   buffer[i++] = (uint8_t)(addr & 0xFF);
 
-  spi_dev->write_then_read(buffer, i, values, count);
+  return spi_dev->write_then_read(buffer, i, values, count);
 }
 
 /*!
@@ -277,12 +277,14 @@ void Adafruit_FRAM_SPI::read(uint32_t addr, uint8_t *values, size_t count) {
  *          Product ID fields (bytes 7..0). Should be 0x0302 for
  *          the MB85RS64VPNF-G-JNERE1.
  */
-void Adafruit_FRAM_SPI::getDeviceID(uint8_t *manufacturerID,
+bool Adafruit_FRAM_SPI::getDeviceID(uint8_t *manufacturerID,
                                     uint16_t *productID) {
   uint8_t cmd = OPCODE_RDID;
   uint8_t a[4] = {0, 0, 0, 0};
 
-  spi_dev->write_then_read(&cmd, 1, a, 4);
+  if( !spi_dev->write_then_read(&cmd, 1, a, 4) ) {
+    return false;
+  }
 
   if (a[1] == 0x7f) {
     // Device with continuation code (0x7F) in their second byte
@@ -295,6 +297,8 @@ void Adafruit_FRAM_SPI::getDeviceID(uint8_t *manufacturerID,
     *manufacturerID = (a[0]);
     *productID = (a[1] << 8) + a[2];
   }
+
+  return true;
 }
 
 /*!
@@ -316,13 +320,13 @@ uint8_t Adafruit_FRAM_SPI::getStatusRegister() {
  *   @param  value
  *           value that will be set
  */
-void Adafruit_FRAM_SPI::setStatusRegister(uint8_t value) {
+bool Adafruit_FRAM_SPI::setStatusRegister(uint8_t value) {
   uint8_t cmd[2];
 
   cmd[0] = OPCODE_WRSR;
   cmd[1] = value;
 
-  spi_dev->write(cmd, 2);
+  return spi_dev->write(cmd, 2);
 }
 
 /*!

--- a/Adafruit_FRAM_SPI.h
+++ b/Adafruit_FRAM_SPI.h
@@ -47,14 +47,14 @@ public:
   Adafruit_FRAM_SPI(int8_t clk, int8_t miso, int8_t mosi, int8_t cs);
 
   bool begin(uint8_t nAddressSizeBytes = 2);
-  void writeEnable(bool enable);
-  void write8(uint32_t addr, uint8_t value);
-  void write(uint32_t addr, const uint8_t *values, size_t count);
+  bool writeEnable(bool enable);
+  bool write8(uint32_t addr, uint8_t value);
+  bool write(uint32_t addr, const uint8_t *values, size_t count);
   uint8_t read8(uint32_t addr);
-  void read(uint32_t addr, uint8_t *values, size_t count);
-  void getDeviceID(uint8_t *manufacturerID, uint16_t *productID);
+  bool read(uint32_t addr, uint8_t *values, size_t count);
+  bool getDeviceID(uint8_t *manufacturerID, uint16_t *productID);
   uint8_t getStatusRegister(void);
-  void setStatusRegister(uint8_t value);
+  bool setStatusRegister(uint8_t value);
   void setAddressSize(uint8_t nAddressSize);
 
 private:


### PR DESCRIPTION
Hello,

I noticed that write and read functions of this library does not return anything, even though the Adafruit_SPI instance returns a bool value. Thus, I added bool returns to the read and write functions except write8 and getStatusRegister functions because they return a uint8_t value. I didn't touch these parts not to break compatibility with anyone. If it is possible, they may need this change as well in the future. Without the bool return value, we may not understand if the SPI operation was successful or not. The changes compile but I didn't test this library on real hardware. But, the changes are minimal and it should be ok as far as I can see. If any mistakes occur, I will make another pull request.

Thanks for the library.