### PR TITLE
conditional compile debug output

### DIFF
--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -34,6 +34,7 @@
 
 #include "Adafruit_FRAM_SPI.h"
 
+/// Enable debug output
 #define FRAM_DEBUG 0
 
 /// Supported flash devices

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -154,21 +154,21 @@ bool Adafruit_FRAM_SPI::begin(uint8_t nAddressSizeBytes) {
   _dev_idx = get_supported_idx(manufID, prodID);
 
   if (_dev_idx == -1) {
-    #if FRAM_DEBUG
+#if FRAM_DEBUG
     Serial.print(F("Unexpected Device: Manufacturer ID = 0x"));
     Serial.print(manufID, HEX);
     Serial.print(F(", Product ID = 0x"));
     Serial.println(prodID, HEX);
-    #endif
+#endif
 
     return false;
   } else {
     uint32_t const fram_size = _supported_devices[_dev_idx].size;
 
-    #if FRAM_DEBUG
+#if FRAM_DEBUG
     Serial.print(F("FRAM Size = 0x"));
     Serial.println(fram_size, HEX);
-    #endif
+#endif
 
     // Detect address size in bytes either 2 or 3 bytes (4 bytes is not
     // supported)

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -34,6 +34,8 @@
 
 #include "Adafruit_FRAM_SPI.h"
 
+#define FRAM_DEBUG 0
+
 /// Supported flash devices
 const struct {
   uint8_t manufID;    ///< Manufacture ID
@@ -152,15 +154,21 @@ bool Adafruit_FRAM_SPI::begin(uint8_t nAddressSizeBytes) {
   _dev_idx = get_supported_idx(manufID, prodID);
 
   if (_dev_idx == -1) {
+    #if FRAM_DEBUG
     Serial.print(F("Unexpected Device: Manufacturer ID = 0x"));
     Serial.print(manufID, HEX);
     Serial.print(F(", Product ID = 0x"));
     Serial.println(prodID, HEX);
+    #endif
+
     return false;
   } else {
-    uint32_t fram_size = _supported_devices[_dev_idx].size;
+    uint32_t const fram_size = _supported_devices[_dev_idx].size;
+
+    #if FRAM_DEBUG
     Serial.print(F("FRAM Size = 0x"));
     Serial.println(fram_size, HEX);
+    #endif
 
     // Detect address size in bytes either 2 or 3 bytes (4 bytes is not
     // supported)


### PR DESCRIPTION
When using the library I get debug output to the terminal, which is unwanted for 2 reasons:

1. it screws up the terminal output of my application
2. it needs memory space which is very spare in my project.

My application looks like this:

//#define DEBUG // enables some debug messages

#include <SPI.h>
#include "Adafruit_FRAM_SPI.h"

....
....

void setup()
{
  if (!fram.begin(FRAM_ADDR_SIZE)) {
    Serial.println(F("No FRAM found"));
    exit(1);
  }
  ...
  ...
}

So if I should run into problems with the FRAM module I can enable additional DEBUG output to see what happens. But only then and not in the production version of the software.
