### PR TITLE
added Fujitsu MB85RS4MT FRAM; added sleep mode

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -3,15 +3,20 @@ name: Arduino Library CI
 on: [pull_request, push, repository_dispatch]
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+
   build:
     runs-on: ubuntu-latest
-    
     steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - uses: actions/checkout@v3
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
       with:
          repository: adafruit/ci-arduino
          path: ci
@@ -21,9 +26,6 @@ jobs:
 
     - name: test platforms
       run: python3 ci/build_platform.py main_platforms
-
-    - name: clang
-      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 
 
     - name: doxygen
       env:

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -3,19 +3,14 @@ name: Arduino Library CI
 on: [pull_request, push, repository_dispatch]
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
-
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+
+    - name: Run pre-commit
+      uses: pre-commit/action@v3.0.1
+
     - uses: actions/checkout@v4
       with:
          repository: adafruit/ci-arduino

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2020 Diego Elio Pettenò
+#
+# SPDX-License-Identifier: Unlicense
+
+repos:
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v15.0.7
+  hooks:
+  - id: clang-format
+    types_or: [c++, c, header]

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -46,6 +46,7 @@ const struct {
     {0x04, 0x2503, 32 * 1024UL},  // MB85RS256TY
     {0x04, 0x2703, 128 * 1024UL}, // MB85RS1MT
     {0x04, 0x4803, 256 * 1024UL}, // MB85RS2MTA
+    {0x04, 0x2803, 256 * 1024UL}, // MB85RS2MT
     {0x04, 0x4903, 512 * 1024UL}, // MB85RS4MT
 
     // Cypress
@@ -343,3 +344,39 @@ bool Adafruit_FRAM_SPI::setStatusRegister(uint8_t value) {
 void Adafruit_FRAM_SPI::setAddressSize(uint8_t nAddressSize) {
   _nAddressSizeBytes = nAddressSize;
 }
+
+/*!
+ *  @brief  Enters the FRAM's low power sleep mode
+ *  @return true if successful
+ */
+// WARNING: this method has not yet been validated
+bool Adafruit_FRAM_SPI::enter_low_power_mode(void) {
+  uint8_t cmd;
+
+  cmd = OPCODE_SLEEP;
+
+  return spi_dev->write(&cmd, 1);
+}
+
+
+/*!
+ *  @brief  exits the FRAM's low power sleep mode
+ *  @return true if successful
+ */
+// WARNING: this method has not yet been validated
+bool Adafruit_FRAM_SPI::exit_low_power_mode(void) {
+  uint8_t cmd;
+
+  // Returning to an normal operation from the SLEEP mode is carried out after tREC (Max 400 μs)
+  // time from the falling edge of CS
+  spi_dev->beginTransactionWithAssertingCS();
+  delayMicroseconds(300);
+  // It is possible to return CS to H level before tREC time. However, it
+  // is prohibited to bring down CS to L level again during tREC period.
+  spi_dev->endTransactionWithDeassertingCS();
+  delayMicroseconds(100);
+
+  return spi_dev->write(&cmd, 1);
+}
+
+

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -25,36 +25,39 @@
  *  @section license License
  *
  *  BSD license, all text above must be included in any redistribution
+ *
+ *  History
+ *  - FUEL4EP: Added sleep mode support
  */
 
-#include <math.h>
 #include <stdlib.h>
 
 #include "Adafruit_FRAM_SPI.h"
 
 /// Supported flash devices
 const struct {
-  uint8_t manufID; ///< Manufacture ID
-  uint16_t prodID; ///< Product ID
-  uint32_t size;   ///< Size in bytes
+  uint8_t manufID;    ///< Manufacture ID
+  uint16_t prodID;    ///< Product ID
+  uint32_t size;      ///< Size in bytes
+  bool support_sleep; ///< Support sleep mode
 } _supported_devices[] = {
     // Sorted in numerical order
     // Fujitsu
-    {0x04, 0x0101, 2 * 1024UL},   // MB85RS16
-    {0x04, 0x0302, 8 * 1024UL},   // MB85RS64V
-    {0x04, 0x2303, 8 * 1024UL},   // MB85RS64T
-    {0x04, 0x2503, 32 * 1024UL},  // MB85RS256TY
-    {0x04, 0x2703, 128 * 1024UL}, // MB85RS1MT
-    {0x04, 0x4803, 256 * 1024UL}, // MB85RS2MTA
-    {0x04, 0x2803, 256 * 1024UL}, // MB85RS2MT
-    {0x04, 0x4903, 512 * 1024UL}, // MB85RS4MT
+    {0x04, 0x0101, 2 * 1024UL, false},  // MB85RS16
+    {0x04, 0x0302, 8 * 1024UL, false},  // MB85RS64V
+    {0x04, 0x2303, 8 * 1024UL, true},   // MB85RS64T
+    {0x04, 0x2503, 32 * 1024UL, true},  // MB85RS256TY
+    {0x04, 0x2703, 128 * 1024UL, true}, // MB85RS1MT
+    {0x04, 0x4803, 256 * 1024UL, true}, // MB85RS2MTA
+    {0x04, 0x2803, 256 * 1024UL, true}, // MB85RS2MT
+    {0x04, 0x4903, 512 * 1024UL, true}, // MB85RS4MT
 
     // Cypress
-    {0x7F, 0x7F7f, 32 * 1024UL}, // FM25V02
-                                 // (manu = 7F7F7F7F7F7FC2, device = 0x2200)
+    {0x7F, 0x7F7f, 32 * 1024UL, false}, // FM25V02
+    // (manu = 7F7F7F7F7F7FC2, device = 0x2200)
 
     // Lapis
-    {0xAE, 0x8305, 8 * 1024UL} // MR45V064B
+    {0xAE, 0x8305, 8 * 1024UL, false} // MR45V064B
 };
 
 /*!
@@ -63,22 +66,25 @@ const struct {
  *          ManufactureID to be checked
  *  @param  prodID
  *          ProductID to be checked
- *  @return size of device, 0 if not supported
+ *  @return device index, -1 if not supported
  */
-static uint32_t check_supported_device(uint8_t manufID, uint16_t prodID) {
-  for (uint8_t i = 0;
+static int get_supported_idx(uint8_t manufID, uint16_t prodID) {
+  for (int i = 0;
        i < sizeof(_supported_devices) / sizeof(_supported_devices[0]); i++) {
     if (manufID == _supported_devices[i].manufID &&
         prodID == _supported_devices[i].prodID)
-      return _supported_devices[i].size;
+      return i;
   }
 
-  Serial.print(F("Unexpected Device: Manufacturer ID = 0x"));
-  Serial.print(manufID, HEX);
-  Serial.print(F(", Product ID = 0x"));
-  Serial.println(prodID, HEX);
+  return -1;
+}
 
-  return 0;
+/*!
+ * @brief  Initialize the SPI FRAM class
+ */
+void Adafruit_FRAM_SPI::init(void) {
+  _nAddressSizeBytes = 0;
+  _dev_idx = -1;
 }
 
 /*!
@@ -92,10 +98,7 @@ static uint32_t check_supported_device(uint8_t manufID, uint16_t prodID) {
  */
 Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t cs, SPIClass *theSPI,
                                      uint32_t freq) {
-  if (spi_dev) {
-    delete spi_dev;
-  }
-
+  init();
   spi_dev = new Adafruit_SPIDevice(cs, freq, SPI_BITORDER_MSBFIRST, SPI_MODE0,
                                    theSPI);
 }
@@ -113,12 +116,15 @@ Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t cs, SPIClass *theSPI,
  */
 Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t clk, int8_t miso, int8_t mosi,
                                      int8_t cs) {
+  init();
+  spi_dev = new Adafruit_SPIDevice(cs, clk, miso, mosi, 1000000,
+                                   SPI_BITORDER_MSBFIRST, SPI_MODE0);
+}
+
+Adafruit_FRAM_SPI::~Adafruit_FRAM_SPI(void) {
   if (spi_dev) {
     delete spi_dev;
   }
-
-  spi_dev = new Adafruit_SPIDevice(cs, clk, miso, mosi, 1000000,
-                                   SPI_BITORDER_MSBFIRST, SPI_MODE0);
 }
 
 /*!
@@ -129,8 +135,8 @@ Adafruit_FRAM_SPI::Adafruit_FRAM_SPI(int8_t clk, int8_t miso, int8_t mosi,
  *  @return true if successful
  */
 bool Adafruit_FRAM_SPI::begin(uint8_t nAddressSizeBytes) {
-  (void)
-      nAddressSizeBytes; // not used anymore, since we will use auto-detect size
+  // not used anymore, since we will use auto-detect size
+  (void)nAddressSizeBytes;
 
   /* Configure SPI */
   if (!spi_dev->begin()) {
@@ -143,19 +149,29 @@ bool Adafruit_FRAM_SPI::begin(uint8_t nAddressSizeBytes) {
   getDeviceID(&manufID, &prodID);
 
   /* Everything seems to be properly initialised and connected */
-  uint32_t fram_size = check_supported_device(manufID, prodID);
+  _dev_idx = get_supported_idx(manufID, prodID);
 
-  Serial.print(F("FRAM Size = 0x"));
-  Serial.println(fram_size, HEX);
-
-  // Detect address size in bytes either 2 or 3 bytes (4 bytes is not supported)
-  if (fram_size > 64UL * 1024) {
-    setAddressSize(3);
+  if (_dev_idx == -1) {
+    Serial.print(F("Unexpected Device: Manufacturer ID = 0x"));
+    Serial.print(manufID, HEX);
+    Serial.print(F(", Product ID = 0x"));
+    Serial.println(prodID, HEX);
+    return false;
   } else {
-    setAddressSize(2);
-  }
+    uint32_t fram_size = _supported_devices[_dev_idx].size;
+    Serial.print(F("FRAM Size = 0x"));
+    Serial.println(fram_size, HEX);
 
-  return fram_size != 0;
+    // Detect address size in bytes either 2 or 3 bytes (4 bytes is not
+    // supported)
+    if (fram_size > 64UL * 1024) {
+      setAddressSize(3);
+    } else {
+      setAddressSize(2);
+    }
+
+    return true;
+  }
 }
 
 /*!
@@ -188,10 +204,12 @@ bool Adafruit_FRAM_SPI::write8(uint32_t addr, uint8_t value) {
   uint8_t i = 0;
 
   buffer[i++] = OPCODE_WRITE;
-  if (_nAddressSizeBytes > 3)
+  if (_nAddressSizeBytes > 3) {
     buffer[i++] = (uint8_t)(addr >> 24);
-  if (_nAddressSizeBytes > 2)
+  }
+  if (_nAddressSizeBytes > 2) {
     buffer[i++] = (uint8_t)(addr >> 16);
+  }
   buffer[i++] = (uint8_t)(addr >> 8);
   buffer[i++] = (uint8_t)(addr & 0xFF);
   buffer[i++] = value;
@@ -215,10 +233,12 @@ bool Adafruit_FRAM_SPI::write(uint32_t addr, const uint8_t *values,
   uint8_t i = 0;
 
   prebuf[i++] = OPCODE_WRITE;
-  if (_nAddressSizeBytes > 3)
+  if (_nAddressSizeBytes > 3) {
     prebuf[i++] = (uint8_t)(addr >> 24);
-  if (_nAddressSizeBytes > 2)
+  }
+  if (_nAddressSizeBytes > 2) {
     prebuf[i++] = (uint8_t)(addr >> 16);
+  }
   prebuf[i++] = (uint8_t)(addr >> 8);
   prebuf[i++] = (uint8_t)(addr & 0xFF);
 
@@ -236,10 +256,12 @@ uint8_t Adafruit_FRAM_SPI::read8(uint32_t addr) {
   uint8_t i = 0;
 
   buffer[i++] = OPCODE_READ;
-  if (_nAddressSizeBytes > 3)
+  if (_nAddressSizeBytes > 3) {
     buffer[i++] = (uint8_t)(addr >> 24);
-  if (_nAddressSizeBytes > 2)
+  }
+  if (_nAddressSizeBytes > 2) {
     buffer[i++] = (uint8_t)(addr >> 16);
+  }
   buffer[i++] = (uint8_t)(addr >> 8);
   buffer[i++] = (uint8_t)(addr & 0xFF);
 
@@ -263,10 +285,12 @@ bool Adafruit_FRAM_SPI::read(uint32_t addr, uint8_t *values, size_t count) {
   uint8_t i = 0;
 
   buffer[i++] = OPCODE_READ;
-  if (_nAddressSizeBytes > 3)
+  if (_nAddressSizeBytes > 3) {
     buffer[i++] = (uint8_t)(addr >> 24);
-  if (_nAddressSizeBytes > 2)
+  }
+  if (_nAddressSizeBytes > 2) {
     buffer[i++] = (uint8_t)(addr >> 16);
+  }
   buffer[i++] = (uint8_t)(addr >> 8);
   buffer[i++] = (uint8_t)(addr & 0xFF);
 
@@ -350,11 +374,11 @@ void Adafruit_FRAM_SPI::setAddressSize(uint8_t nAddressSize) {
  *  @return true if successful
  */
 // WARNING: this method has not yet been validated
-bool Adafruit_FRAM_SPI::enter_low_power_mode(void) {
-  uint8_t cmd;
-
-  cmd = OPCODE_SLEEP;
-
+bool Adafruit_FRAM_SPI::enterSleep(void) {
+  if (_dev_idx == -1 || !_supported_devices[_dev_idx].support_sleep) {
+    return false;
+  }
+  uint8_t cmd = OPCODE_SLEEP;
   return spi_dev->write(&cmd, 1);
 }
 
@@ -363,10 +387,12 @@ bool Adafruit_FRAM_SPI::enter_low_power_mode(void) {
  *  @return true if successful
  */
 // WARNING: this method has not yet been validated
-bool Adafruit_FRAM_SPI::exit_low_power_mode(void) {
-  uint8_t cmd;
+bool Adafruit_FRAM_SPI::exitSleep(void) {
+  if (_dev_idx == -1 || !_supported_devices[_dev_idx].support_sleep) {
+    return false;
+  }
 
-  // Returning to an normal operation from the SLEEP mode is carried out after
+  // Returning to a normal operation from the SLEEP mode is carried out after
   // tREC (Max 400 μs) time from the falling edge of CS
   spi_dev->beginTransactionWithAssertingCS();
   delayMicroseconds(300);
@@ -375,5 +401,5 @@ bool Adafruit_FRAM_SPI::exit_low_power_mode(void) {
   spi_dev->endTransactionWithDeassertingCS();
   delayMicroseconds(100);
 
-  return spi_dev->write(&cmd, 1);
+  return true;
 }

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -358,7 +358,6 @@ bool Adafruit_FRAM_SPI::enter_low_power_mode(void) {
   return spi_dev->write(&cmd, 1);
 }
 
-
 /*!
  *  @brief  exits the FRAM's low power sleep mode
  *  @return true if successful
@@ -367,8 +366,8 @@ bool Adafruit_FRAM_SPI::enter_low_power_mode(void) {
 bool Adafruit_FRAM_SPI::exit_low_power_mode(void) {
   uint8_t cmd;
 
-  // Returning to an normal operation from the SLEEP mode is carried out after tREC (Max 400 μs)
-  // time from the falling edge of CS
+  // Returning to an normal operation from the SLEEP mode is carried out after
+  // tREC (Max 400 μs) time from the falling edge of CS
   spi_dev->beginTransactionWithAssertingCS();
   delayMicroseconds(300);
   // It is possible to return CS to H level before tREC time. However, it
@@ -378,5 +377,3 @@ bool Adafruit_FRAM_SPI::exit_low_power_mode(void) {
 
   return spi_dev->write(&cmd, 1);
 }
-
-

--- a/Adafruit_FRAM_SPI.h
+++ b/Adafruit_FRAM_SPI.h
@@ -35,7 +35,7 @@ typedef enum opcodes_e {
   OPCODE_READ = 0b0011,     /* Read Memory */
   OPCODE_WRITE = 0b0010,    /* Write Memory */
   OPCODE_RDID = 0b10011111, /* Read Device ID */
-  OPCODE_SLEEP = 0b10111001 /* Sleep Mode by FUEL4EP */
+  OPCODE_SLEEP = 0b10111001 /* Sleep Mode */
 } opcodes_t;
 
 /*!
@@ -47,6 +47,7 @@ public:
   Adafruit_FRAM_SPI(int8_t cs, SPIClass *theSPI = &SPI,
                     uint32_t freq = 1000000);
   Adafruit_FRAM_SPI(int8_t clk, int8_t miso, int8_t mosi, int8_t cs);
+  virtual ~Adafruit_FRAM_SPI(void);
 
   bool begin(uint8_t nAddressSizeBytes = 2);
   bool writeEnable(bool enable);
@@ -58,12 +59,14 @@ public:
   uint8_t getStatusRegister(void);
   bool setStatusRegister(uint8_t value);
   void setAddressSize(uint8_t nAddressSize);
-  bool enter_low_power_mode(void); // added by FUEL4EP
-  bool exit_low_power_mode(void);  // added by FUEL4EP
+  bool enterSleep(void);
+  bool exitSleep(void);
 
 private:
-  Adafruit_SPIDevice *spi_dev = NULL;
+  void init(void);
+  Adafruit_SPIDevice *spi_dev;
   uint8_t _nAddressSizeBytes;
+  int _dev_idx;
 };
 
 #endif

--- a/Adafruit_FRAM_SPI.h
+++ b/Adafruit_FRAM_SPI.h
@@ -18,6 +18,7 @@
  *
  *  BSD license, all text above must be included in any redistribution
  */
+
 #ifndef _ADAFRUIT_FRAM_SPI_H_
 #define _ADAFRUIT_FRAM_SPI_H_
 
@@ -27,13 +28,14 @@
 
 /** Operation Codes **/
 typedef enum opcodes_e {
-  OPCODE_WREN = 0b0110,    /* Write Enable Latch */
-  OPCODE_WRDI = 0b0100,    /* Reset Write Enable Latch */
-  OPCODE_RDSR = 0b0101,    /* Read Status Register */
-  OPCODE_WRSR = 0b0001,    /* Write Status Register */
-  OPCODE_READ = 0b0011,    /* Read Memory */
-  OPCODE_WRITE = 0b0010,   /* Write Memory */
-  OPCODE_RDID = 0b10011111 /* Read Device ID */
+  OPCODE_WREN  = 0b0110,     /* Write Enable Latch */
+  OPCODE_WRDI  = 0b0100,     /* Reset Write Enable Latch */
+  OPCODE_RDSR  = 0b0101,     /* Read Status Register */
+  OPCODE_WRSR  = 0b0001,     /* Write Status Register */
+  OPCODE_READ  = 0b0011,     /* Read Memory */
+  OPCODE_WRITE = 0b0010,     /* Write Memory */
+  OPCODE_RDID  = 0b10011111, /* Read Device ID */
+  OPCODE_SLEEP = 0b10111001  /* Sleep Mode  */ // added by FUEL4EP
 } opcodes_t;
 
 /*!
@@ -56,6 +58,8 @@ public:
   uint8_t getStatusRegister(void);
   bool setStatusRegister(uint8_t value);
   void setAddressSize(uint8_t nAddressSize);
+  bool enter_low_power_mode(void); // added by FUEL4EP
+  bool exit_low_power_mode(void);  // added by FUEL4EP
 
 private:
   Adafruit_SPIDevice *spi_dev = NULL;

--- a/Adafruit_FRAM_SPI.h
+++ b/Adafruit_FRAM_SPI.h
@@ -28,14 +28,14 @@
 
 /** Operation Codes **/
 typedef enum opcodes_e {
-  OPCODE_WREN  = 0b0110,     /* Write Enable Latch */
-  OPCODE_WRDI  = 0b0100,     /* Reset Write Enable Latch */
-  OPCODE_RDSR  = 0b0101,     /* Read Status Register */
-  OPCODE_WRSR  = 0b0001,     /* Write Status Register */
-  OPCODE_READ  = 0b0011,     /* Read Memory */
-  OPCODE_WRITE = 0b0010,     /* Write Memory */
-  OPCODE_RDID  = 0b10011111, /* Read Device ID */
-  OPCODE_SLEEP = 0b10111001  /* Sleep Mode  */ // added by FUEL4EP
+  OPCODE_WREN = 0b0110,     /* Write Enable Latch */
+  OPCODE_WRDI = 0b0100,     /* Reset Write Enable Latch */
+  OPCODE_RDSR = 0b0101,     /* Read Status Register */
+  OPCODE_WRSR = 0b0001,     /* Write Status Register */
+  OPCODE_READ = 0b0011,     /* Read Memory */
+  OPCODE_WRITE = 0b0010,    /* Write Memory */
+  OPCODE_RDID = 0b10011111, /* Read Device ID */
+  OPCODE_SLEEP = 0b10111001 /* Sleep Mode by FUEL4EP */
 } opcodes_t;
 
 /*!

--- a/examples/FRAMInfo/FRAMInfo.ino
+++ b/examples/FRAMInfo/FRAMInfo.ino
@@ -1,36 +1,38 @@
-#include <SPI.h>
 #include "Adafruit_FRAM_SPI.h"
+#include <SPI.h>
 
-/* Example code to interrogate Adafruit SPI FRAM breakout for address size and storage capacity */
+/* Example code to interrogate Adafruit SPI FRAM breakout for address size and
+ * storage capacity */
 
 /* NOTE: This sketch will overwrite data already on the FRAM breakout */
 
 uint8_t FRAM_CS = 10;
-Adafruit_FRAM_SPI fram = Adafruit_FRAM_SPI(FRAM_CS);  // use hardware SPI
+Adafruit_FRAM_SPI fram = Adafruit_FRAM_SPI(FRAM_CS); // use hardware SPI
 
 uint8_t FRAM_SCK = 13;
 uint8_t FRAM_MISO = 12;
 uint8_t FRAM_MOSI = 11;
-//Or use software SPI, any pins!
-//Adafruit_FRAM_SPI fram = Adafruit_FRAM_SPI(FRAM_SCK, FRAM_MISO, FRAM_MOSI, FRAM_CS);
+// Or use software SPI, any pins!
+// Adafruit_FRAM_SPI fram = Adafruit_FRAM_SPI(FRAM_SCK, FRAM_MISO, FRAM_MOSI,
+// FRAM_CS);
 
-uint8_t           addrSizeInBytes = 2; //Default to address size of two bytes
-uint32_t          memSize;
+uint8_t addrSizeInBytes = 2; // Default to address size of two bytes
+uint32_t memSize;
 
 int32_t readBack(uint32_t addr, int32_t data) {
   int32_t check = !data;
   int32_t wrapCheck, backup;
-  fram.read(addr, (uint8_t*)&backup, sizeof(int32_t));
+  fram.read(addr, (uint8_t *)&backup, sizeof(int32_t));
   fram.writeEnable(true);
-  fram.write(addr, (uint8_t*)&data, sizeof(int32_t));
+  fram.write(addr, (uint8_t *)&data, sizeof(int32_t));
   fram.writeEnable(false);
-  fram.read(addr, (uint8_t*)&check, sizeof(int32_t));
-  fram.read(0, (uint8_t*)&wrapCheck, sizeof(int32_t));
+  fram.read(addr, (uint8_t *)&check, sizeof(int32_t));
+  fram.read(0, (uint8_t *)&wrapCheck, sizeof(int32_t));
   fram.writeEnable(true);
-  fram.write(addr, (uint8_t*)&backup, sizeof(int32_t));
+  fram.write(addr, (uint8_t *)&backup, sizeof(int32_t));
   fram.writeEnable(false);
   // Check for warparound, address 0 will work anyway
-  if (wrapCheck==check)
+  if (wrapCheck == check)
     check = 0;
   return check;
 }
@@ -42,17 +44,18 @@ bool testAddrSize(uint8_t addrSize) {
   return false;
 }
 
-
 void setup(void) {
   Serial.begin(9600);
 
-  while (!Serial) delay(10);     // will pause Zero, Leonardo, etc until serial console opens
-  
+  while (!Serial)
+    delay(10); // will pause Zero, Leonardo, etc until serial console opens
+
   if (fram.begin(addrSizeInBytes)) {
     Serial.println("Found SPI FRAM");
   } else {
     Serial.println("No SPI FRAM found ... check your connections\r\n");
-    while (1);
+    while (1)
+      ;
   }
 
   if (testAddrSize(2))
@@ -62,28 +65,32 @@ void setup(void) {
   else if (testAddrSize(4))
     addrSizeInBytes = 4;
   else {
-    Serial.println("SPI FRAM can not be read/written with any address size\r\n");
-    while (1);
+    Serial.println(
+        "SPI FRAM can not be read/written with any address size\r\n");
+    while (1)
+      ;
   }
-  
+
   memSize = 0;
   while (readBack(memSize, memSize) == memSize) {
     memSize += 256;
-    //Serial.print("Block: #"); Serial.println(memSize/256);
+    // Serial.print("Block: #"); Serial.println(memSize/256);
   }
-  
+
   Serial.print("SPI FRAM address size is ");
   Serial.print(addrSizeInBytes);
   Serial.println(" bytes.");
   Serial.println("SPI FRAM capacity appears to be..");
-  Serial.print(memSize); Serial.println(" bytes");
-  Serial.print(memSize/0x400); Serial.println(" kilobytes");
-  Serial.print((memSize*8)/0x400); Serial.println(" kilobits");
-  if (memSize >= (0x100000/8)) {
-    Serial.print((memSize*8)/0x100000); Serial.println(" megabits");
+  Serial.print(memSize);
+  Serial.println(" bytes");
+  Serial.print(memSize / 0x400);
+  Serial.println(" kilobytes");
+  Serial.print((memSize * 8) / 0x400);
+  Serial.println(" kilobits");
+  if (memSize >= (0x100000 / 8)) {
+    Serial.print((memSize * 8) / 0x100000);
+    Serial.println(" megabits");
   }
 }
 
-void loop(void) {
-
-}
+void loop(void) {}

--- a/examples/MB85RS64V/MB85RS64V.ino
+++ b/examples/MB85RS64V/MB85RS64V.ino
@@ -1,37 +1,42 @@
-#include <SPI.h>
 #include "Adafruit_FRAM_SPI.h"
+#include <SPI.h>
 
 /* Example code for the Adafruit SPI FRAM breakout */
 uint8_t FRAM_CS = 10;
 
-//Adafruit_FRAM_SPI fram = Adafruit_FRAM_SPI(FRAM_CS);  // use hardware SPI
+// Adafruit_FRAM_SPI fram = Adafruit_FRAM_SPI(FRAM_CS);  // use hardware SPI
 
-uint8_t FRAM_SCK= 13;
+uint8_t FRAM_SCK = 13;
 uint8_t FRAM_MISO = 12;
 uint8_t FRAM_MOSI = 11;
-//Or use software SPI, any pins!
-Adafruit_FRAM_SPI fram = Adafruit_FRAM_SPI(FRAM_SCK, FRAM_MISO, FRAM_MOSI, FRAM_CS);
+// Or use software SPI, any pins!
+Adafruit_FRAM_SPI fram =
+    Adafruit_FRAM_SPI(FRAM_SCK, FRAM_MISO, FRAM_MOSI, FRAM_CS);
 
-uint16_t          addr = 0;
+uint16_t addr = 0;
 
 void setup(void) {
   Serial.begin(9600);
-  while (!Serial) delay(10);     // will pause Zero, Leonardo, etc until serial console opens
-  
+  while (!Serial)
+    delay(10); // will pause Zero, Leonardo, etc until serial console opens
+
   if (fram.begin()) {
     Serial.println("Found SPI FRAM");
   } else {
     Serial.println("No SPI FRAM found ... check your connections\r\n");
-    while (1);
+    while (1)
+      ;
   }
-  
+
   // Read the first byte
   uint8_t test = fram.read8(0x0);
-  Serial.print("Restarted "); Serial.print(test); Serial.println(" times");
+  Serial.print("Restarted ");
+  Serial.print(test);
+  Serial.println(" times");
 
   // Test write ++
   fram.writeEnable(true);
-  fram.write8(0x0, test+1);
+  fram.write8(0x0, test + 1);
   fram.writeEnable(false);
 
   fram.writeEnable(true);
@@ -43,15 +48,16 @@ void setup(void) {
   for (uint16_t a = 0; a < 8192; a++) {
     value = fram.read8(a);
     if ((a % 32) == 0) {
-      Serial.print("\n 0x"); Serial.print(a, HEX); Serial.print(": ");
+      Serial.print("\n 0x");
+      Serial.print(a, HEX);
+      Serial.print(": ");
     }
-    Serial.print("0x"); 
-    if (value < 0x1) 
+    Serial.print("0x");
+    if (value < 0x1)
       Serial.print('0');
-    Serial.print(value, HEX); Serial.print(" ");
+    Serial.print(value, HEX);
+    Serial.print(" ");
   }
 }
 
-void loop(void) {
-
-}
+void loop(void) {}


### PR DESCRIPTION
Changes of this pull request are:

1. added Fujitsu MB85RS4MT FRAM
2. added sleep mode

The changes have been successfully verified with my PCB [HB-UNI-SEN-BATT_ATMega1284P_E07-868MS10_FRAM_FUEL4EP](https://github.com/FUEL4EP/HomeAutomation/tree/master/AsksinPP_developments/PCBs/HB-UNI-SEN-BATT_ATMega1284P_E07-868MS10_FRAM_FUEL4EP).
In sleep  mode, the current dissipation has been reduced from 30 uA (without sleep mode) to 12 uA (with sleep mode).
