### PR TITLE
Add device ID for MB85RS64VYPNF

### DIFF
--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -48,6 +48,7 @@ const struct {
     // Fujitsu
     {0x04, 0x0101, 2 * 1024UL, false},  // MB85RS16
     {0x04, 0x0302, 8 * 1024UL, false},  // MB85RS64V
+    {0x04, 0x2302, 8 * 1024UL, true},   // MB85RS64VYPNF
     {0x04, 0x2303, 8 * 1024UL, true},   // MB85RS64T
     {0x04, 0x2503, 32 * 1024UL, true},  // MB85RS256TY
     {0x04, 0x2703, 128 * 1024UL, true}, // MB85RS1MT
@@ -55,7 +56,6 @@ const struct {
     {0x04, 0x2803, 256 * 1024UL, true}, // MB85RS2MT
     {0x04, 0x4903, 512 * 1024UL, true}, // MB85RS4MT
     {0x04, 0x490B, 512 * 1024UL, true}, // MB85RS4MTY
-    {0x04, 0x2302, 8 * 1024UL, true}, //MB85RS64VYPNF
 
     // Cypress
     {0x7F, 0x7F7f, 32 * 1024UL, false}, // FM25V02

--- a/Adafruit_FRAM_SPI.cpp
+++ b/Adafruit_FRAM_SPI.cpp
@@ -55,6 +55,7 @@ const struct {
     {0x04, 0x2803, 256 * 1024UL, true}, // MB85RS2MT
     {0x04, 0x4903, 512 * 1024UL, true}, // MB85RS4MT
     {0x04, 0x490B, 512 * 1024UL, true}, // MB85RS4MTY
+    {0x04, 0x2302, 8 * 1024UL, true}, //MB85RS64VYPNF
 
     // Cypress
     {0x7F, 0x7F7f, 32 * 1024UL, false}, // FM25V02


### PR DESCRIPTION
It appears that the MB85RS64V used on the breakouts is no longer going to be available, replaced by the very nearly identical MB85RS64VYPNF. This device has a different ID, though, so this change simply adds it to the list of known devices. I've tested it with the real hardware, and it appears to work identically to the MB85RS64V.